### PR TITLE
feat: Google Token Credentials using Type-Safe Middleware

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],    
     dependencies: [
-         .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", .branch("typeSafeMiddleware")),
+        .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.2.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,10 @@ let package = Package(
         .target(
             name: "CredentialsGoogle",
             dependencies: ["Credentials"]
+        ),
+        .testTarget(
+            name: "CredentialsGoogleTests",
+            dependencies: ["CredentialsGoogle"]
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],    
     dependencies: [
-         .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", .upToNextMinor(from: "2.1.0")),
+         .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", .branch("typeSafeMiddleware")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/CredentialsGoogle/GoogleTokenProfile.swift
+++ b/Sources/CredentialsGoogle/GoogleTokenProfile.swift
@@ -14,6 +14,9 @@
  * limitations under the License.
  **/
 
+// Note, import not required, but code necessary to separate comment blocks for Jazzy to document the struct below.
+import Foundation
+
 /**
  A pre-constructed TypeSafeGoogleToken which contains the default fields that can be
  requested from Google.
@@ -22,10 +25,9 @@
  to the data.
 
  ### Usage Example: ###
-
  ```swift
  router.get("/googleProfile") { (user: GoogleTokenProfile, respondWith: (GoogleTokenProfile?, RequestError?) -> Void) in
- respondWith(user, nil)
+    respondWith(user, nil)
  }
  ```
  */
@@ -59,6 +61,6 @@ public struct GoogleTokenProfile: TypeSafeGoogleToken {
     public let email: String?
     
     /// Indicates whether the subject's e-mail address has been verified. Note that
-    /// this field is only present if `email` is has been granted.
+    /// this field is only present if `email` has been granted.
     public let verified_email: Bool?
 }

--- a/Sources/CredentialsGoogle/GoogleTokenProfile.swift
+++ b/Sources/CredentialsGoogle/GoogleTokenProfile.swift
@@ -14,35 +14,51 @@
  * limitations under the License.
  **/
 
-/// A pre-constructed TypeSafeGoogleToken which contains the default
-/// that can be requested from Google.
-///
-/// Note that the Optional fields will only be initialized if the user's OAuth token grants
-/// access to the data, and many extended permissions require a Facebook app review prior
-/// to that app being allowed to request them.
 /**
+ A pre-constructed TypeSafeGoogleToken which contains the default fields that can be
+ requested from Google.
+
+ Note that the Optional fields will only be initialized if the subject grants access
+ to the data.
+
  ### Usage Example: ###
+
+ ```swift
  router.get("/googleProfile") { (user: GoogleTokenProfile, respondWith: (GoogleTokenProfile?, RequestError?) -> Void) in
  respondWith(user, nil)
  }
+ ```
  */
 public struct GoogleTokenProfile: TypeSafeGoogleToken {
     
+    /// The subject's unique Google identifier.
     public let id: String
     
+    /// The subject's display name.
     public let name: String
     
+    /// The subject's family name (last name).
     public let family_name: String
     
-    public let picture: String
-    
-    public let locale: String
-    
-    public let gender: String
-    
-    public let email: String?
-    
+    /// The subject's given name (first name).
     public let given_name: String
     
-    public let verified_email: Bool
+    /// A URL providing access to the subject's profile picture.
+    public let picture: String
+    
+    /// The subject's locale, for example: `en`.
+    public let locale: String
+    
+    // MARK: Optional fields
+    
+    /// The subject's gender. The subject may not have provided this information in
+    /// their Google profile.
+    public let gender: String?
+    
+    /// The subject's e-mail address. The subject may choose not to share this information.
+    public let email: String?
+    
+    /// Indicates whether the subject's e-mail address has been verified. Note that
+    /// this field is only present if `email` is has been granted.
+    public let verified_email: Bool?
 }

--- a/Sources/CredentialsGoogle/GoogleTokenProfile.swift
+++ b/Sources/CredentialsGoogle/GoogleTokenProfile.swift
@@ -1,0 +1,48 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+/// A pre-constructed TypeSafeGoogleToken which contains the default
+/// that can be requested from Google.
+///
+/// Note that the Optional fields will only be initialized if the user's OAuth token grants
+/// access to the data, and many extended permissions require a Facebook app review prior
+/// to that app being allowed to request them.
+/**
+ ### Usage Example: ###
+ router.get("/googleProfile") { (user: GoogleTokenProfile, respondWith: (GoogleTokenProfile?, RequestError?) -> Void) in
+ respondWith(user, nil)
+ }
+ */
+public struct GoogleTokenProfile: TypeSafeGoogleToken {
+    
+    public let id: String
+    
+    public let name: String
+    
+    public let family_name: String
+    
+    public let picture: String
+    
+    public let locale: String
+    
+    public let gender: String
+    
+    public let email: String?
+    
+    public let given_name: String
+    
+    public let verified_email: Bool
+}

--- a/Sources/CredentialsGoogle/TypeSafeGoogle.swift
+++ b/Sources/CredentialsGoogle/TypeSafeGoogle.swift
@@ -1,0 +1,82 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import KituraNet
+import Credentials
+import LoggerAPI
+
+/// A protocol that defines common attributes of Facebook authentication methods.
+///
+/// It is not intended for a user's type to conform to this protocol directly. Instead,
+/// your type should conform to a specific authentication type, such as
+/// `TypeSafeFacebookToken`.
+public protocol TypeSafeGoogle: TypeSafeCredentials {
+
+}
+
+extension TypeSafeGoogle {
+    /// Provides a default provider name of `Google`.
+    public var provider: String {
+        return "Google"
+    }
+
+    /// Gets a subject's profile information from Google using an access token, and
+    /// returns an instance of `Self` by decoding the response from Google using JSONDecoder.
+    ///
+    /// Failure could occur if the response from Google could not be decoded to our type. An
+    /// example of when failure might occur is if the user's type declares a field that the
+    /// subject declines to share as a non-optional type, for example: `let email: String`.
+    ///
+    /// - Parameter token: a Google OAuth token
+    /// - Parameter callback: A callback that will be invoked with an instance of `Self`
+    ///   on success, or `nil` on failure.
+    static func getGoogleProfile(token: String, callback: @escaping (Self?) -> Void) {
+        let googleReq = HTTP.request("https://www.googleapis.com/oauth2/v2/userinfo?access_token=\(token)") { response in
+            // Check we have recieved an OK response from Google
+            guard let response = response else {
+                Log.error("Request to Google failed: response was nil")
+                return callback(nil)
+            }
+            var body = Data()
+            guard response.statusCode == HTTPStatusCode.OK,
+                let _ = try? response.readAllData(into: &body)
+                else {
+                    Log.error("Google request failed: statusCode=\(response.statusCode), body=\(String(data: body, encoding: .utf8) ?? "")")
+                    return callback(nil)
+            }
+            // Attempt to construct the user's type by decoding the Google response
+            guard let profile = decodeGoogleResponse(data: body) else {
+                Log.debug("Google response data: \(String(data: body, encoding: .utf8) ?? "")")
+                return callback(nil)
+            }
+            return callback(profile)
+        }
+        googleReq.end()
+    }
+
+    /// Attempt to decode the JSON response from Google into an instance of `Self`.
+    static func decodeGoogleResponse(data: Data) -> Self? {
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(Self.self, from: data)
+        } catch {
+            Log.error("Failed to decode \(Self.self) from Google response, error=\(error)")
+            return nil
+        }
+    }
+
+}

--- a/Sources/CredentialsGoogle/TypeSafeGoogle.swift
+++ b/Sources/CredentialsGoogle/TypeSafeGoogle.swift
@@ -19,11 +19,11 @@ import KituraNet
 import Credentials
 import LoggerAPI
 
-/// A protocol that defines common attributes of Facebook authentication methods.
+/// A protocol that defines common attributes of Google authentication methods.
 ///
 /// It is not intended for a user's type to conform to this protocol directly. Instead,
 /// your type should conform to a specific authentication type, such as
-/// `TypeSafeFacebookToken`.
+/// `TypeSafeGoogleToken`.
 public protocol TypeSafeGoogle: TypeSafeCredentials {
 
 }

--- a/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
+++ b/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
@@ -1,0 +1,148 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+
+import Kitura
+import KituraNet
+import LoggerAPI
+import Credentials
+import Foundation
+
+public protocol TypeSafeGoogleToken: TypeSafeCredentials {
+    
+    var id: String { get }
+    
+    var name: String { get }
+    
+}
+
+// MARK FacebookCacheElement
+
+/// The cache element for keeping google profile information.
+public class GoogleCacheElement {
+    /// The user profile information stored as `TypeSafeGoogleToken`.
+    public var userProfile: TypeSafeGoogleToken
+    
+    /// Initialize a `FacebookCacheElement`.
+    ///
+    /// - Parameter profile: the `TypeSafeGoogleToken` to store.
+    public init (profile: TypeSafeGoogleToken) {
+        userProfile = profile
+    }
+}
+
+// An internal type to hold the mapping from a user's type to an appropriate token cache.
+//
+// It is a workaround for the inability to define stored properties in a protocol extension.
+//
+// We use the `debugDescription` of the user's type (via `String(reflecting:)`) as the
+// dictionary key.
+private struct TypeSafeGoogleTokenCache {
+    internal static var cacheForType: [String: NSCache<NSString, GoogleCacheElement>] = [:]
+}
+
+extension TypeSafeGoogleToken {
+    // Associates a token cache with the user's type. This relieves the user from having to
+    // declare a usersCache property on their conforming type.
+    private static var usersCache: NSCache<NSString, GoogleCacheElement> {
+        let key = String(reflecting: Self.self)
+        if let usersCache = TypeSafeGoogleTokenCache.cacheForType[key] {
+            return usersCache
+        } else {
+            let usersCache = NSCache<NSString, GoogleCacheElement>()
+            TypeSafeGoogleTokenCache.cacheForType[key] = usersCache
+            return usersCache
+        }
+    }
+    
+    /// Provides a default provider name of `Facebook`.
+    public var provider: String {
+        return "Google"
+    }
+    
+    /// Authenticate incoming request using Facebook OAuth token.
+    ///
+    /// - Parameter request: The `RouterRequest` object used to get information
+    ///                     about the request.
+    /// - Parameter response: The `RouterResponse` object used to respond to the
+    ///                       request.
+    /// - Parameter options: The dictionary of plugin specific options.
+    /// - Parameter onSuccess: The closure to invoke in the case of successful authentication.
+    /// - Parameter onFailure: The closure to invoke in the case of an authentication failure.
+    /// - Parameter onSkip: The closure to invoke when the plugin doesn't recognize
+    ///                     the authentication token in the request.
+    public static func authenticate(request: RouterRequest, response: RouterResponse, onSuccess: @escaping (Self) -> Void, onFailure: @escaping (HTTPStatusCode?, [String : String]?) -> Void, onSkip: @escaping (HTTPStatusCode?, [String : String]?) -> Void) {
+        
+        guard let type = request.headers["X-token-type"], type == "GoogleToken" else {
+            return onSkip(nil, nil)
+        }
+        
+        guard let token = request.headers["access_token"] else {
+            return onFailure(nil, nil)
+        }
+        
+        if let cacheProfile = getFromCache(token: token) {
+            return onSuccess(cacheProfile)
+        }
+        
+        getTokenProfile(token: token, callback: { (tokenProfile) in
+            guard let tokenProfile = tokenProfile else {
+                Log.error("Failed to retrieve Google profile for token")
+                return onFailure(nil, nil)
+            }
+            return onSuccess(tokenProfile)
+        })
+    }
+
+    
+    private static func getTokenProfile(token: String, callback: @escaping (Self?) -> Void) {
+        let fbreq = HTTP.request("https://www.googleapis.com/oauth2/v2/userinfo?access_token=\(token)") { response in
+            // check you have recieved an ok response from Google
+            var body = Data()
+            let decoder = JSONDecoder()
+            guard let response = response,
+                response.statusCode == HTTPStatusCode.OK,
+                let _ = try? response.readAllData(into: &body),
+                let selfInstance = try? decoder.decode(Self.self, from: body)
+                else {
+                    return callback(nil)
+            }
+            
+            #if os(Linux)
+            let key = NSString(string: token)
+            #else
+            let key = token as NSString
+            #endif
+            Self.usersCache.setObject(GoogleCacheElement(profile: selfInstance), forKey: key)
+            return callback(selfInstance)
+        }
+        fbreq.end()
+    }
+    
+    private static func getFromCache(token: String) -> Self? {
+        #if os(Linux)
+        let key = NSString(string: token)
+        #else
+        let key = token as NSString
+        #endif
+        let cacheElement = Self.usersCache.object(forKey: key)
+        return cacheElement?.userProfile as? Self
+    }
+}
+
+
+
+

--- a/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
+++ b/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
@@ -56,7 +56,7 @@ private class GoogleCacheElement {
     /// The user profile information stored as `TypeSafeGoogleToken`.
     var userProfile: TypeSafeGoogleToken
     
-    /// Initialize a `FacebookCacheElement`.
+    /// Initialize a `GoogleCacheElement`.
     ///
     /// - Parameter profile: the `TypeSafeGoogleToken` to store.
     init (profile: TypeSafeGoogleToken) {

--- a/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
+++ b/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
@@ -29,7 +29,7 @@ public protocol TypeSafeGoogleToken: TypeSafeCredentials {
     
 }
 
-// MARK FacebookCacheElement
+// MARK GoogleCacheElement
 
 /// The cache element for keeping google profile information.
 public class GoogleCacheElement {
@@ -84,7 +84,10 @@ extension TypeSafeGoogleToken {
     /// - Parameter onFailure: The closure to invoke in the case of an authentication failure.
     /// - Parameter onSkip: The closure to invoke when the plugin doesn't recognize
     ///                     the authentication token in the request.
-    public static func authenticate(request: RouterRequest, response: RouterResponse, onSuccess: @escaping (Self) -> Void, onFailure: @escaping (HTTPStatusCode?, [String : String]?) -> Void, onSkip: @escaping (HTTPStatusCode?, [String : String]?) -> Void) {
+    public static func authenticate(request: RouterRequest, response: RouterResponse,
+                                    onSuccess: @escaping (Self) -> Void,
+                                    onFailure: @escaping (HTTPStatusCode?, [String : String]?) -> Void,
+                                    onSkip: @escaping (HTTPStatusCode?, [String : String]?) -> Void) {
         
         guard let type = request.headers["X-token-type"], type == "GoogleToken" else {
             return onSkip(nil, nil)

--- a/Tests/CredentialsGoogleTests/CredentialsGoogleTests.swift
+++ b/Tests/CredentialsGoogleTests/CredentialsGoogleTests.swift
@@ -1,0 +1,86 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+
+import Kitura
+import KituraNet
+
+import Foundation
+import Dispatch
+
+
+protocol CredentialsGoogleTest {
+    func expectation(_ index: Int) -> XCTestExpectation
+    func waitExpectation(timeout t: TimeInterval, handler: XCWaitCompletionHandler?)
+}
+
+extension CredentialsGoogleTest {
+
+    func doTearDown() {
+        //       sleep(10)
+    }
+
+    func performServerTest(router: ServerDelegate, asyncTasks: (XCTestExpectation) -> Void...) {
+        do {
+            let server = try HTTPServer.listen(on: 8090, delegate: router)
+            let requestQueue = DispatchQueue(label: "Request queue")
+
+            for (index, asyncTask) in asyncTasks.enumerated() {
+                let expectation = self.expectation(index)
+                requestQueue.sync {
+                    asyncTask(expectation)
+                }
+            }
+
+            waitExpectation(timeout: 10) { error in
+                // blocks test until request completes
+                server.stop()
+                XCTAssertNil(error);
+            }
+        } catch {
+            XCTFail("Error: \(error)")
+        }
+    }
+
+    func performRequest(method: String, host: String = "localhost", path: String, callback: @escaping ClientRequest.Callback, headers: [String: String]? = nil, requestModifier: ((ClientRequest) -> Void)? = nil) {
+        var allHeaders = [String: String]()
+        if  let headers = headers  {
+            for  (headerName, headerValue) in headers  {
+                allHeaders[headerName] = headerValue
+            }
+        }
+        allHeaders["Content-Type"] = "text/plain"
+        let options: [ClientRequest.Options] =
+                [.method(method), .hostname(host), .port(8090), .path(path), .headers(allHeaders)]
+        let req = HTTP.request(options, callback: callback)
+        if let requestModifier = requestModifier {
+            requestModifier(req)
+        }
+        req.end()
+    }
+}
+
+extension XCTestCase: CredentialsGoogleTest {
+    func expectation(_ index: Int) -> XCTestExpectation {
+        let expectationDescription = "\(type(of: self))-\(index)"
+        return self.expectation(description: expectationDescription)
+    }
+
+    func waitExpectation(timeout t: TimeInterval, handler: XCWaitCompletionHandler?) {
+        self.waitForExpectations(timeout: t, handler: handler)
+    }
+}

--- a/Tests/CredentialsGoogleTests/GoogleTokenProfile+Equatable.swift
+++ b/Tests/CredentialsGoogleTests/GoogleTokenProfile+Equatable.swift
@@ -1,0 +1,33 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+@testable import CredentialsGoogle
+
+extension GoogleTokenProfile: Equatable {
+    public static func == (lhs: GoogleTokenProfile, rhs: GoogleTokenProfile) -> Bool {
+        return lhs.id == rhs.id
+            && lhs.name == rhs.name
+            && lhs.provider == rhs.provider
+            && lhs.email == rhs.email
+            && lhs.family_name == rhs.family_name
+            && lhs.gender == rhs.gender
+            && lhs.given_name == rhs.given_name
+            && lhs.locale == rhs.locale
+            && lhs.picture == rhs.picture
+            && lhs.verified_email == rhs.verified_email
+    }
+}
+

--- a/Tests/CredentialsGoogleTests/PrintLogger.swift
+++ b/Tests/CredentialsGoogleTests/PrintLogger.swift
@@ -1,0 +1,80 @@
+/**
+ * Copyright IBM Corporation 2016, 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+
+import LoggerAPI
+
+/// The set of colors used when logging with colorized lines
+public enum TerminalColor: String {
+    /// Log text in white.
+    case white = "\u{001B}[0;37m" // white
+    /// Log text in red, used for error messages.
+    case red = "\u{001B}[0;31m" // red
+    /// Log text in yellow, used for warning messages.
+    case yellow = "\u{001B}[0;33m" // yellow
+    /// Log text in the terminal's default foreground color.
+    case foreground = "\u{001B}[0;39m" // default foreground color
+    /// Log text in the terminal's default background color.
+    case background = "\u{001B}[0;49m" // default background color
+}
+
+public class PrintLogger: Logger {
+    let colored: Bool
+    
+    init(colored: Bool) {
+        self.colored = colored
+    }
+    
+    public func log(_ type: LoggerMessageType, msg: String,
+                    functionName: String, lineNum: Int, fileName: String ) {
+        let message = "[\(type)] [\(getFile(fileName)):\(lineNum) \(functionName)] \(msg)"
+        
+        guard colored else {
+            print(message)
+            return
+        }
+        
+        let color: TerminalColor
+        switch type {
+        case .warning:
+            color = .yellow
+        case .error:
+            color = .red
+        default:
+            color = .foreground
+        }
+        
+        print(color.rawValue + message + TerminalColor.foreground.rawValue)
+    }
+    
+    public func isLogging(_ level: LoggerAPI.LoggerMessageType) -> Bool {
+        return true
+    }
+    
+    public static func use(colored: Bool) {
+        Log.logger = PrintLogger(colored: colored)
+        setbuf(stdout, nil)
+    }
+    
+    private func getFile(_ path: String) -> String {
+        guard let range = path.range(of: "/", options: .backwards) else {
+            return path
+        }
+        
+        return String(path[range.upperBound...])
+    }
+}

--- a/Tests/CredentialsGoogleTests/TestTypeSafeToken.swift
+++ b/Tests/CredentialsGoogleTests/TestTypeSafeToken.swift
@@ -1,0 +1,245 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import Foundation
+import XCTest
+
+import Kitura
+import KituraNet
+import LoggerAPI
+
+@testable import CredentialsGoogle
+
+class TestTypeSafeToken : XCTestCase {
+
+    static var allTests : [(String, (TestTypeSafeToken) -> () throws -> Void)] {
+        return [
+            ("testDefaultTokenProfile", testDefaultTokenProfile),
+            ("testMinimalTokenProfile", testMinimalTokenProfile),
+            ("testCache", testCache),
+            ("testTwoInCache", testTwoInCache),
+            ("testCachedProfile", testCachedProfile),
+            ("testMissingTokenType", testMissingTokenType),
+            ("testMissingAccessToken", testMissingAccessToken),
+        ]
+    }
+
+    override func tearDown() {
+        doTearDown()
+    }
+
+    // An example of a user-defined GoogleToken profile.
+    struct TestGoogleToken: TypeSafeGoogleToken, Equatable {
+        // Fields that should be retrieved from Google
+        var id: String
+        var name: String
+        var email: String?
+
+        // Fields that should be ignored (not part of the Google API)
+        var favouriteArtist: String?
+        var favouriteNumber: Int?
+
+        // Testing requirement: Equatable
+        static func == (lhs: TestGoogleToken, rhs: TestGoogleToken) -> Bool {
+            return lhs.id == rhs.id
+                && lhs.name == rhs.name
+                && lhs.provider == rhs.provider
+                && lhs.email == rhs.email
+                && lhs.favouriteArtist == rhs.favouriteArtist
+                && lhs.favouriteNumber == rhs.favouriteNumber
+        }
+    }
+
+    let token = "Test token"
+    let token2 = "Test token 2"
+
+    // A Google response JSON fragment. Two optional fields are present (email, verified_email).
+    // Another optional field (gender) is not provided.
+    //
+    // This data will be decoded into two types during these tests:
+    // - an instance of GoogleTokenProfile, which is capable of representing all fields (plus
+    //   gender, which is absent from this fragment)
+    // - an instance of TestGoogleToken, which defines only 'id', 'name' and 'email'.
+    let testGoogleResponse = """
+{
+  "family_name": "Doe",
+  "name": "John Doe",
+  "picture": "https://lh4.googleusercontent.com/-abc123/abc123/abc123/abc123/photo.jpg",
+  "locale": "en",
+  "email": "john_doe@invalid.com",
+  "given_name": "John",
+  "id": "123456789012345678901",
+  "verified_email": true
+}
+""".data(using: .utf8)!
+
+    // A second Google response JSON fragment, used when testing multiple tokens in a single
+    // cache. This subject has declined to share their e-mail address.
+    let testGoogleResponse2 = """
+{
+  "family_name": "Doe",
+  "name": "Jane Doe",
+  "picture": "https://lh4.googleusercontent.com/-xyz456/xyz456/xyz456/xyz456/photo.jpg",
+  "locale": "en",
+  "given_name": "Jane",
+  "id": "112233445566778899001"
+}
+""".data(using: .utf8)!
+
+    let router = TestTypeSafeToken.setupCodableRouter()
+
+    // Tests that the pre-constructed GoogleTokenProfile type maps correctly to the
+    // JSON response retrieved from the Google user profile API.
+    func testDefaultTokenProfile() {
+        guard let profileInstance = GoogleTokenProfile.decodeGoogleResponse(data: testGoogleResponse) else {
+            return XCTFail("Facebook JSON response cannot be decoded to GoogleTokenProfile")
+        }
+        // An equivalent test profile, constructed directly.
+        let testTokenProfile = GoogleTokenProfile(id: "123456789012345678901", name: "John Doe", family_name: "Doe", given_name: "John", picture: "https://lh4.googleusercontent.com/-abc123/abc123/abc123/abc123/photo.jpg", locale: "en", gender: nil, email: "john_doe@invalid.com", verified_email: true)
+
+        XCTAssertEqual(profileInstance, testTokenProfile, "The reference GoogleTokenProfile instance did not match the instance decoded from the Google JSON response")
+    }
+
+    // Tests that a minimal TypeSafeGoogleToken can be decoded from the same Google
+    // JSON response, and that it matches the content that we expect.
+    func testMinimalTokenProfile() {
+        guard let profileInstance = TestGoogleToken.decodeGoogleResponse(data: testGoogleResponse) else {
+            return XCTFail("Google JSON response cannot be decoded to TestGoogleToken")
+        }
+        let expectedProfile = TestGoogleToken(id: "123456789012345678901", name: "John Doe", email: "john_doe@invalid.com", favouriteArtist: nil, favouriteNumber: nil)
+        XCTAssertEqual(profileInstance, expectedProfile, "The reference TestGoogleToken instance did not match the instance decoded from the Google JSON response")
+    }
+    
+    // Tests that a profile can be saved and retreived from the cache
+    func testCache() {
+        guard let profileInstance = TestGoogleToken.decodeGoogleResponse(data: testGoogleResponse) else {
+            return XCTFail("Google JSON response cannot be decoded to TestGoogleToken")
+        }
+        TestGoogleToken.saveInCache(profile: profileInstance, token: token)
+        guard let cacheProfile = TestGoogleToken.getFromCache(token: token) else {
+            return XCTFail("Failed to get from cache")
+        }
+        XCTAssertEqual(cacheProfile, profileInstance, "retrieved different profile from cache")
+    }
+
+    // Tests that two different profiles can be saved and retreived from the cache
+    func testTwoInCache() {
+        guard let profileInstance1 = TestGoogleToken.decodeGoogleResponse(data: testGoogleResponse) else {
+            return XCTFail("Google JSON response cannot be decoded to TestGoogleToken")
+        }
+        guard let profileInstance2 = TestGoogleToken.decodeGoogleResponse(data: testGoogleResponse2) else {
+            return XCTFail("Google JSON response cannot be decoded to GoogleTokenProfile")
+        }
+        TestGoogleToken.saveInCache(profile: profileInstance1, token: token)
+        TestGoogleToken.saveInCache(profile: profileInstance2, token: token2)
+        guard let cacheProfile1 = TestGoogleToken.getFromCache(token: token) else {
+            return XCTFail("Failed to get from cache")
+        }
+        guard let cacheProfile2 = TestGoogleToken.getFromCache(token: token2) else {
+            return XCTFail("Failed to get from cache")
+        }
+        XCTAssertEqual(cacheProfile1, profileInstance1, "retrieved different profile from cache1")
+        XCTAssertEqual(cacheProfile2, profileInstance2, "retrieved different profile from cache2")
+    }
+
+    // Tests that a profile stored in the token cache can be retrieved and returned by a Codable
+    // route that includes this middleware.
+    func testCachedProfile() {
+        guard let profileInstance = TestGoogleToken.decodeGoogleResponse(data: testGoogleResponse) else {
+            return XCTFail("Google JSON response cannot be decoded to TestGoogleToken")
+        }
+        TestGoogleToken.saveInCache(profile: profileInstance, token: token)
+        performServerTest(router: router) { expectation in
+            // Note that currently, this request to /multipleHandlers will fail, as both handlers
+            // are invoked and both write a JSON response body (which is itself invalid JSON).
+            // If Codable routing in the future equates the writing of data with ending the
+            // response, this would work.
+            self.performRequest(method: "get", path: "/singleHandler", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
+                do {
+                    guard let body = try response?.readString(), let tokenData = body.data(using: .utf8) else {
+                        XCTFail("No response body")
+                        return
+                    }
+                    let decoder = JSONDecoder()
+                    let profile = try decoder.decode(TestGoogleToken.self, from: tokenData)
+                    XCTAssertEqual(profile, profileInstance, "Body \(profile) is not equal to \(profileInstance)")
+                } catch {
+                    XCTFail("Could not decode response: \(error)")
+                }
+                expectation.fulfill()
+            }, headers: ["X-token-type" : "GoogleToken", "access_token" : self.token])
+        }
+    }
+
+    // Tests that when a request to a Codable route that includes this middleware does not
+    // contain the matching X-token-type header, the middleware skips authentication and a
+    // second handler is instead invoked.
+    func testMissingTokenType() {
+        performServerTest(router: router) { expectation in
+            self.performRequest(method: "get", path: "/multipleHandlers", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.OK, "HTTP Status code was \(String(describing: response?.statusCode))")
+                do {
+                    guard let body = try response?.readString(), let responseData = body.data(using: .utf8) else {
+                        XCTFail("No response body")
+                        return
+                    }
+                    let decoder = JSONDecoder()
+                    let testResponse = try decoder.decode(TestGoogleToken.self, from: responseData)
+                    let expectedResponse = TestGoogleToken(id: "123", name: "abc", email: "def", favouriteArtist: "ghi", favouriteNumber: 123)
+                    XCTAssertEqual(testResponse, expectedResponse, "Response from second handler did not contain expected data")
+                } catch {
+                    XCTFail("Could not decode response: \(error)")
+                }
+                expectation.fulfill()
+            }, headers: ["access_token" : self.token])
+        }
+    }
+
+    // Tests that when a request to a Codable route that includes this middleware contains
+    // the matching X-token-type header, but does not supply an access_token, the middleware
+    // fails authentication and returns unauthorized.
+    func testMissingAccessToken() {
+        performServerTest(router: router) { expectation in
+            self.performRequest(method: "get", path: "/multipleHandlers", callback: {response in
+                XCTAssertNotNil(response, "ERROR!!! ClientRequest response object was nil")
+                XCTAssertEqual(response?.statusCode, HTTPStatusCode.unauthorized, "HTTP Status code was \(String(describing: response?.statusCode))")
+                expectation.fulfill()
+            }, headers: ["X-token-type" : "GoogleToken"])
+        }
+    }
+
+    static func setupCodableRouter() -> Router {
+        let router = Router()
+        PrintLogger.use(colored: true)
+
+        router.get("/singleHandler") { (profile: TestGoogleToken, respondWith: (TestGoogleToken?, RequestError?) -> Void) in
+            respondWith(profile, nil)
+        }
+
+        router.get("/multipleHandlers") { (profile: TestGoogleToken, respondWith: (TestGoogleToken?, RequestError?) -> Void) in
+            respondWith(profile, nil)
+        }
+
+        router.get("/multipleHandlers") { (respondWith: (TestGoogleToken?, RequestError?) -> Void) in
+            respondWith(TestGoogleToken(id: "123", name: "abc", email: "def", favouriteArtist: "ghi", favouriteNumber: 123), nil)
+        }
+
+        return router
+    }
+}

--- a/Tests/CredentialsGoogleTests/TestTypeSafeToken.swift
+++ b/Tests/CredentialsGoogleTests/TestTypeSafeToken.swift
@@ -105,7 +105,7 @@ class TestTypeSafeToken : XCTestCase {
     // JSON response retrieved from the Google user profile API.
     func testDefaultTokenProfile() {
         guard let profileInstance = GoogleTokenProfile.decodeGoogleResponse(data: testGoogleResponse) else {
-            return XCTFail("Facebook JSON response cannot be decoded to GoogleTokenProfile")
+            return XCTFail("Google JSON response cannot be decoded to GoogleTokenProfile")
         }
         // An equivalent test profile, constructed directly.
         let testTokenProfile = GoogleTokenProfile(id: "123456789012345678901", name: "John Doe", family_name: "Doe", given_name: "John", picture: "https://lh4.googleusercontent.com/-abc123/abc123/abc123/abc123/photo.jpg", locale: "en", gender: nil, email: "john_doe@invalid.com", verified_email: true)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,24 @@
+/**
+ * Copyright IBM Corporation 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import XCTest
+
+@testable import CredentialsGoogleTests
+
+
+XCTMain([
+            testCase(TestTypeSafeToken.allTests)
+])


### PR DESCRIPTION
Introduces a `TypeSafeGoogleToken` protocol which implements the `TypeSafeCredentials` and `TypeSafeMiddleware` protocols, that can be passed to a user's Codable Routing handler representing a user authenticated using a Google OAuth token.

A default implementation `GoogleTokenProfile` has been provided, which serves as a sample, or can be used as-is if the user does not want to further customize their type.

The requirements of a type-safe Google token middleware are:
- The type must conform to `TypeSafeGoogleToken`, which itself conforms to `Codable`. Any properties must therefore be `Codable`.
- The type must be a `struct` or a `final class`. The class must be final because the `TypeSafeMiddleware` protocol includes a static function with a `Self` type reference.

When defining a conformance to `TypeSafeGoogleToken`, the user must define:
- `id: String` representing the (app-scoped) unique identifier for a subject,
- `name: String` representing the subject's display name,
- additional properties may be declared matching the available fields from the Google user profile API. Examples of such properties are included in the `GoogleTokenProfile`.

An example declaration:
```swift
import CredentialsGoogle

// Defines the user's session instance data.
struct MyGoogleToken: TypeSafeGoogleToken {
    let id: String
    let name: String
    let email: String?
}
```