### PR TITLE
feat: Add token time to live

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         )
     ],    
     dependencies: [
-        .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.2.0"),
+        .package(url: "https://github.com/IBM-Swift/Kitura-Credentials.git", from: "2.4.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/CredentialsGoogle/CredentialsGoogleToken.swift
+++ b/Sources/CredentialsGoogle/CredentialsGoogleToken.swift
@@ -36,7 +36,7 @@ public class CredentialsGoogleToken: CredentialsPluginProtocol {
     }
     
     /// The time in seconds since the user profile was generated that the access token will be considered valid.
-    public var tokenTimeToLive: Int?
+    public var tokenTimeToLive: TimeInterval?
 
     private var delegate: UserProfileDelegate?
     
@@ -82,7 +82,7 @@ public class CredentialsGoogleToken: CredentialsPluginProtocol {
                 #endif
                 if let cached = usersCache?.object(forKey: key) {
                     if let ttl = tokenTimeToLive {
-                        if Date() < cached.createdAt.addingTimeInterval(TimeInterval(ttl)) {
+                        if Date() < cached.createdAt.addingTimeInterval(ttl) {
                             onSuccess(cached.userProfile)
                             return
                         }

--- a/Sources/CredentialsGoogle/CredentialsGoogleToken.swift
+++ b/Sources/CredentialsGoogle/CredentialsGoogleToken.swift
@@ -36,7 +36,7 @@ public class CredentialsGoogleToken: CredentialsPluginProtocol {
     }
     
     /// The time in seconds since the user profile was generated that the access token will be considered valid.
-    public var tokenTimeToLive: TimeInterval?
+    public let tokenTimeToLive: TimeInterval?
 
     private var delegate: UserProfileDelegate?
     
@@ -48,8 +48,9 @@ public class CredentialsGoogleToken: CredentialsPluginProtocol {
     /// Initialize a `CredentialsGoogleToken` instance.
     ///
     /// - Parameter options: A dictionary of plugin specific options. The keys are defined in `CredentialsGoogleOptions`.
-    public init(options: [String:Any]?=nil) {
+    public init(options: [String:Any]?=nil, tokenTimeToLive: TimeInterval? = nil) {
         delegate = options?[CredentialsGoogleOptions.userProfileDelegate] as? UserProfileDelegate
+        self.tokenTimeToLive = tokenTimeToLive
     }
     
     /// User profile cache.
@@ -86,8 +87,10 @@ public class CredentialsGoogleToken: CredentialsPluginProtocol {
                             onSuccess(cached.userProfile)
                             return
                         }
-                    // If no time to live set use token until it is evicted from the cache
+                        // If current time is later than time to live, continue to standard token authentication.
+                        // Don't need to evict token, since it will replaced if the token is successfully autheticated.
                     } else {
+                        // No time to live set, use token until it is evicted from the cache
                         onSuccess(cached.userProfile)
                         return
                     }

--- a/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
+++ b/Sources/CredentialsGoogle/TypeSafeGoogleToken.swift
@@ -56,7 +56,7 @@ public protocol TypeSafeGoogleToken: TypeSafeGoogle {
     static var cacheSize: Int { get }
     
     /// The time in seconds since the user profile was generated that the access token will be considered valid.
-    static var tokenTimeToLive: Int? { get }
+    static var tokenTimeToLive: TimeInterval? { get }
 
 }
 
@@ -96,7 +96,7 @@ extension TypeSafeGoogleToken {
     }
     
     /// Default for tokenTimeToLive is nil meaning the token will be considered valid as long as it is in the cache.
-    public static var tokenTimeToLive: Int? {
+    public static var tokenTimeToLive: TimeInterval? {
         return nil
     }
 
@@ -166,7 +166,7 @@ extension TypeSafeGoogleToken {
             return nil
         }
         if let ttl = Self.tokenTimeToLive,
-            cacheElement.createdAt.addingTimeInterval(TimeInterval(ttl)) < Date()
+            cacheElement.createdAt.addingTimeInterval(ttl) < Date()
         {
             return nil
         }


### PR DESCRIPTION
This pull request Uses the cache timestamp that has been added in [this pr](https://github.com/IBM-Swift/Kitura-Credentials/pull/78) to set a time to live for access tokens. This is the maximum time in seconds after they are first authenticated that the cached user profile for the access token will be used before the token is invalidated and a new request to Facebook to authentication is performed. 

Since this is dependent on the PR to Credentials, this will not pass Travis until that PR is merged.

Once this is approved and merged we should implement similar features in [CredentialsGithub](https://github.com/IBM-Swift/Kitura-CredentialsGitHub) and [CredentialsFacebook](https://github.com/IBM-Swift/Kitura-CredentialsFacebook)