### PR TITLE
ci: Enable Xcode11 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,10 @@ matrix:
     - os: osx
       osx_image: xcode10.2
       sudo: required
-# Pending Travis Xcode 11 image
-#    - os: osx
-#      osx_image: xcode11
-#      sudo: required
-#      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+    - os: osx
+      osx_image: xcode11
+      sudo: required
+      env: SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/Sources/CredentialsGoogle/CredentialsGoogle.swift
+++ b/Sources/CredentialsGoogle/CredentialsGoogle.swift
@@ -106,7 +106,7 @@ public class CredentialsGoogle: CredentialsPluginProtocol {
                     do {
                         var body = Data()
                         try googleResponse.readAllData(into: &body)
-                        if var jsonBody = try JSONSerialization.jsonObject(with: body, options: []) as? [String : Any],
+                        if let jsonBody = try JSONSerialization.jsonObject(with: body, options: []) as? [String : Any],
                         let token = jsonBody["access_token"] as? String {
                             requestOptions = []
                             requestOptions.append(.schema("https://"))


### PR DESCRIPTION
Travis recently published an `xcode11` macOS image.  This enables the macOS 5.1 CI testing.
Also resolve a compile warning.